### PR TITLE
deobfuscate erigon archive link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Multi-threaded download via aria2, nothing more
 # install dependencies
 sudo apt-get install -y aria2 curl jq
 # download snapshot
-curl -skL https://bit.ly/3znHXPc | bash
+curl -skL https://raw.githubusercontent.com/48Club/bsc-snapshots/refs/heads/main/script/erigon_archive_download.sh | bash
 mv snapshots /data/erigon
 # start erigon
 erigon3 --prune.mode=archive --chain=bsc --datadir=/data/erigon ...


### PR DESCRIPTION
Piping bit.ly into bash is probably too much, someone could take control of that link and change it so it points to malicious code.

If the only reason bit.ly was used is to shorten the URL, then I'd recommend just leaving the long link.

PS: you are doing an awesome work contributing these to the community!